### PR TITLE
添加了开机自启功能的代码

### DIFF
--- a/Wins/SettingsWin.xaml
+++ b/Wins/SettingsWin.xaml
@@ -14,6 +14,7 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="*" />
             <RowDefinition Height="*" />
+            <RowDefinition Height="*" />
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="*" />
@@ -55,5 +56,10 @@
                 </Binding>
             </Button.Content>
         </Button>
+        
+        <Button Grid.Row="2" Grid.Column="0" Margin="5" Content="启用/修复 程序开机自启动" ToolTip="{Binding Source={x:Static consts:SettingsConst.ColorsButtonToolTip}}"
+                Click="Enabled_SelfStarting_Click"/>
+        <Button Grid.Row="2" Grid.Column="1" Margin="5" Content="禁用 程序开机自启动" ToolTip="{Binding Source={x:Static consts:SettingsConst.ColorsButtonToolTip}}"
+                Click="Disabled_SelfStarting_Click" />
     </Grid>
 </Window>


### PR DESCRIPTION
你好，我想为这个很赞的项目做出一些贡献。我为该软件添加了开机自启动的功能。
我暂时将启用开机自启的功能按钮放在了界面设置窗口中，我认为你能给这些按钮找到更好的位置。
开机自启时，会给软件加上-selfStarting参数，可以在后续添加相应操作。
该功能的大致原理是，点击启动按钮后，会先向用户请求管理员权限，随后执行cmd命令进行注册表修改来实现开启程序的开机自启。使用外部cmd进行的原因是，可以在执行开机自启的时候向用户申请管理员权限，而不需要一开始使用管理员权限启动应用。据我所知，非管理员权限的应用是不能在不重启应用的情况下提升自己的权限的。