### PR TITLE
新增从github上一键检查更新的功能

### DIFF
--- a/Sheas-Cealer.csproj
+++ b/Sheas-Cealer.csproj
@@ -77,6 +77,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Mvvm" Version="*" />
+    <PackageReference Include="EasyUpdateFromGithub" Version="1.3.3.20241216" />
     <PackageReference Include="MaterialDesignThemes" Version="*" />
     <PackageReference Include="NginxConfigParser" Version="*" />
     <PackageReference Include="YamlDotNet" Version="*" />

--- a/Utils/AutoCheckUpdate.cs
+++ b/Utils/AutoCheckUpdate.cs
@@ -1,0 +1,79 @@
+﻿using EasyUpdateFromGithub;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Forms;
+using YamlDotNet.Core;
+using MessageBox = System.Windows.MessageBox;
+
+namespace Sheas_Cealer.Utils {
+	internal class AutoCheckUpdate:Window {
+		/// <summary>
+		/// 对话框标题
+		/// </summary>
+		const string msgboxTitle = "更新检查";
+		readonly UpdateFromGithub ufg = new() {
+			RepositoryURL = "https://github.com/SpaceTimee/Sheas-Cealer",
+			ProgramVersion= Assembly.GetExecutingAssembly().GetName().Version!.ToString(),
+			EasySetCacheDir= "SheasCealer",
+		};
+		/// <summary>
+		/// 表示当前是否正在执行程序更新函数，如果正在执行，则为true，阻止多次调用函数
+		/// </summary>
+		bool isCheckingUpdate=false;
+		/// <summary>
+		/// 程序更新函数
+		/// </summary>
+		/// <param name="isAuto">是否是自动检查更新，如果不是，则在检查完后反馈</param>
+		internal async void ProgramUpdateAsync(bool isAuto = false) {
+			if (!isCheckingUpdate) {
+				isCheckingUpdate = true;
+				try {
+					UpdateFromGithub.CheckUpdateValue cuv = await ufg.CheckUpdateAsync();
+					//获取Release页面latest版本中文件名符合正则表达式的文件
+					UpdateFromGithub.InfoOfDownloadFile iodf=await ufg.GetDownloadFileInfoAsync(fileRegex:new(@"Sheas-Cealer-Zip-.+"));
+					if (cuv.HaveUpdate) {
+						switch (MessageBox.Show(
+@$"检查到可用的更新，是否进行更新？
+当前版本: V{ufg.ProgramVersion}
+最新版本: {cuv.LatestVersionStr}
+发布时间: {cuv.PublishedTime_Local}
+大小: {iodf.Size}"
+										, msgboxTitle, MessageBoxButton.YesNo, MessageBoxImage.Information)) {
+							case MessageBoxResult.Yes:
+								static void errorMsg() {
+									MessageBox.Show("下载更新失败！", msgboxTitle, MessageBoxButton.OK, MessageBoxImage.Error);
+								}
+								try {
+									//下载目标文件
+									UpdateFromGithub.InfoOfInstall? ioi = await ufg.DownloadReleaseAsync(iodf);
+									if (ioi != null) {
+										if (MessageBox.Show("最新版本下载完毕，是否执行安装？", msgboxTitle, MessageBoxButton.YesNo, MessageBoxImage.Information) == MessageBoxResult.Yes) {
+											ufg.InstallFile(ioi, waitTime: 900);
+											this.Close();//执行安装时需要退出主程序
+										}
+									}
+									else 
+										errorMsg();
+								} catch { errorMsg(); }
+								break;
+							default:
+								break;
+						}
+					}
+					else if (!isAuto)
+						MessageBox.Show("当前已是最新版本", msgboxTitle, MessageBoxButton.OK, MessageBoxImage.Information);
+				} catch {
+					if (!isAuto)
+						MessageBox.Show("更新检查失败！", msgboxTitle, MessageBoxButton.OK, MessageBoxImage.Error);
+				}
+				isCheckingUpdate = false;
+			}
+		}
+	}
+}

--- a/Wins/MainWin.xaml.cs
+++ b/Wins/MainWin.xaml.cs
@@ -82,6 +82,10 @@ public partial class MainWin : Window
 
             MihomoConfWatcher_Changed(null!, null!);
         });
+        //这是一个检查更新的示例，后续可以将其放置在检查更新按钮的点击事件内，或者放在窗口加载事件内
+        AutoCheckUpdate acu = new();
+        //当isAuto参数为false时，检查完更新后会进行一个反馈弹窗，为true则不会
+        acu.ProgramUpdateAsync(false);
     }
     private void MainWin_Closing(object sender, CancelEventArgs e) => Application.Current.Shutdown();
 


### PR DESCRIPTION
为实现此功能添加了我的一个依赖包: [EasyUpdateFromGithub](https://github.com/Hgnim/EasyUpdateFromGithub)
实例化AutoCheckUpdate类后调用ProgramUpdateAsync方法即可从github release中检测是否有可用的更新，如果有，则询问用户是否更新，如果没有或无法访问或其它错误，则根据参数决定是否进行反馈弹窗。
检查更新的大致流程是，首先通过github api获取release latest中的tag信息且将其转换为整型，将其与软件当前已经转换为整型的版本号进行对比，以判断是否需要更新。如果包含可用更新且用户已点击确认更新，则开始从github release latest中下载二进制文件压缩包至系统临时目录并解压，释放出临时程序。下载完毕后会询问用户是否开始安装，开始安装时启动临时程序并退出主程序，临时程序将把解压在系统临时目录中的新文件覆盖旧文件以实现版本更新，文件移动完毕后尝试重新打开程序并关闭临时程序。
该功能目前只进行了简单的调试，在投入至正式版前请进行试错和调整。