### PR TITLE
修一个有关检测端口占用的小问题

### DIFF
--- a/Wins/MainWin.xaml.cs
+++ b/Wins/MainWin.xaml.cs
@@ -204,6 +204,8 @@ public partial class MainWin : Window
     {
         HoldButtonTimer?.Stop();
 
+		NginxConfWatcher_Changed(null!, null!);
+		
         if (!MainPres.IsConginxRunning && !MainPres.IsNginxRunning)
         {
             if (NginxCleaner.IsNginxCleaningSemaphore.CurrentCount == 0 || !await IsNginxLaunchingSemaphore.WaitAsync(0))
@@ -772,13 +774,9 @@ public partial class MainWin : Window
         NginxHttpPort = 80;
         NginxHttpsPort = 443;
 
-        foreach (IPEndPoint activeTcpListener in IPGlobalProperties.GetIPGlobalProperties().GetActiveTcpListeners())
-            if (activeTcpListener.Port == NginxHttpPort)
-                NginxHttpPort++;
-            else if (activeTcpListener.Port == NginxHttpsPort)
-                NginxHttpsPort++;
-            else if (activeTcpListener.Port > NginxHttpsPort)
-                break;
+        HashSet<int> activePorts = new(IPGlobalProperties.GetIPGlobalProperties().GetActiveTcpListeners().Select(listener => listener.Port));
+        while (activePorts.Contains(NginxHttpPort)) NginxHttpPort++;
+        while (activePorts.Contains(NginxHttpsPort)) NginxHttpsPort++;
 
         await using FileStream nginxConfStream = new(MainConst.NginxConfPath, FileMode.OpenOrCreate, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
         NginxConfig extraNginxConfig = NginxConfig.Load(ExtraNginxConfs = new StreamReader(nginxConfStream).ReadToEnd());


### PR DESCRIPTION
# 概述
启动全局伪造的时候对已占用端口的检测不正确，当端口被释放时不能及时检测。
# 问题复现
**先启动Sheas-Cealer**，再占用80或443端口（如启动Nginx模拟端口占用的情况），然后点击启动全局伪造，此时端口占用不能被正确检测到。
同样，**先占用80或443端口**，然后再启动Sheas-Cealer，点击启动全局伪造，此时可以正确检测端口占用，但停止对80或443端口的占用后，再点击启动全局伪造，此时依然提示端口占用。
# 问题分析
观察有关源码发现，变量`NginxHttpPort`和`NginxHttpsPort`依靠触发`NginxConfWatcher_Changed`来更新，但是`NginxConfWatcher_Changed`在上述问题中只在`MainWin_Loaded`中触发。**需要在合适的时机添加对`NginxConfWatcher_Changed`的触发，例如`NginxButtonHoldTimer_Tick`。**
# 修改建议
```csharp
    private async void NginxButtonHoldTimer_Tick(object? sender, EventArgs e)
    {
        HoldButtonTimer?.Stop();

        NginxConfWatcher_Changed(null!, null!);

        // 省略其他代码
    }
```
```csharp
    private async void NginxConfWatcher_Changed(object sender, FileSystemEventArgs e)
    {
        // 省略其他代码

        // 采用更高性能的方式检测端口占用，按原逻辑并未考虑极端情况
        HashSet<int> activePorts = new(IPGlobalProperties.GetIPGlobalProperties().GetActiveTcpListeners().Select(listener => listener.Port));
        while (activePorts.Contains(NginxHttpPort)) NginxHttpPort++;
        while (activePorts.Contains(NginxHttpsPort)) NginxHttpsPort++;

        // 省略其他代码
    }
```
_*开Nginx忘关再使用[Sheas-Cealer](https://github.com/SpaceTimee/Sheas-Cealer)的时候发现的。_